### PR TITLE
Tests pexels API using package and client

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "dotenv": "^16.0.3",
+    "pexels": "^1.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.11.2"

--- a/src/Book.jsx
+++ b/src/Book.jsx
@@ -1,26 +1,37 @@
 import { useEffect, useState } from "react";
+import { createClient } from "pexels";
+
 
 const Book = () => {
-  const [imageGallery, setImageGallery] = useState([]);
+    const [imageGallery, setImageGallery] = useState([]);
 
-  useEffect(() => {
-    fetch(`https://api.pexels.com/v1/search?query=coffee&per_page=15`, {
-      headers: {
-        'Access-Control-Allow-Origin': 'https://the-brew-buddy.onrender.com/',
-        'Authorization': `${process.env.PEXELS_API_KEY}`,
-      },
-    })
-      .then((response) => response.json())
-      .then((data) => {
-        setImageGallery(data.photos);
-      });
-  });
+    const client = createClient(
+        `${process.env.REACT_APP_PEXELS_API_KEY}`
+    );
+
+    const query = "Coffee";
+    
+    client.photos.search({ query, per_page: 5 }).then((photos) => {
+      setImageGallery(photos.photos);
+    });
+
+  //   useEffect(() => {
+  //     fetch(`https://api.pexels.com/v1/search?query=coffee&per_page=15`, {
+  //       headers: {
+  //         'Access-Control-Allow-Origin': 'https://the-brew-buddy.onrender.com/',
+  //         'Authorization': `${process.env.PEXELS_API_KEY}`,
+  //       },
+  //     })
+  //       .then((response) => response.json())
+  //       .then((data) => {
+  //         setImageGallery(data.photos);
+  //       });
+  //   });
 
   const changeImage = (event) => {
     event.preventDefault();
     console.log(imageGallery);
-
-  }
+  };
 
   return (
     <>


### PR DESCRIPTION
Due to CORS issues, I attempted to fetch images using the documentation-provided method of installing the pexels package and using their client vs. a traditional fetch API call. This fix works locally during testing, next step is to test on deployed site.